### PR TITLE
Update Deepnote launch button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-- Latest official GAP release (GAP 4.11.1) [<img src="https://deepnote.com/buttons/launch-in-deepnote-white-small.svg">](https://deepnote.com/launch?url=https%3A%2F%2Fgithub.com%2FZachNewbery%2Ftry-gap-in-deepnote)
+- Latest official GAP release (GAP 4.11.1) [<img src="https://deepnote.com/buttons/launch-in-deepnote-white-small.svg">](https://deepnote.com/project/GAP-Kernel-6I_gbA2oTJeS-h3UCNbvRQ)
 # Deepnote
 [Deepnote](https://deepnote.com/) is a web-based data science notebook that is Jupyter-compatible. It allows for real-time collaboration helping to bring teams and projects together. No installation is required, and can be used on any OS that has a browser. All notebooks on Deepnote are run on machines in the cloud, which can be customised to the needs of each project (with some features gated behind a subscription). To find out more, access the [docs](https://docs.deepnote.com).
 

--- a/README.md
+++ b/README.md
@@ -4,17 +4,18 @@
 
 # GAP in Deepnote
 This repository attempts to integrate the GAP kernel with Deepnote as a Jupyter Notebook. It does not require a local GAP installation, and can be accessed through the browser. To start a new GAP session, do the following:
-1. Click on the "Launch Deepnote" badge at the top of this read-me, which will take you to a new project setup for you in Deepnote.
-2. Since Deepnote defaults to a Python kernel for new projects, you will need to click the "Environment" tab on the left-hand side, and then click the drop-down menu under the "Environment" heading, and select the option "Local ./Dockerfile".
-3. After a few moments, the Dockerfile will open up in the editor on the right-hand side. You may come across an error saying "This project is not currently using an environment defined by this Dockerfile". If that is the case, simply click the "Build" button on the top right, until the Dockerfile is built (or it uses a cached environment from a previous build). You may be prompted to restart the hardware, which can be done by clicking the link in the error message.
-4. Further, you may encounter a "Build timeout" error. This can be solved by simply building the Dockerfile again.
+1. Click on the "Launch Deepnote" badge at the top of this read-me, which will take you to an existing project setup for you in Deepnote.
+2. To execute your own code, you can click the "Duplicate" button which will setup a new project for you to work with.
+3. To make sure that everythin is setup correctly, you can click the "Environment" tab on the left-hand side, and ensure it is set to "Local ./Dockerfile".
+4. If not, select that option from the dropdown. The Dockerfile will then open up in the editor on the right-hand side. You may come across an error saying "This project is not currently using an environment defined by this Dockerfile". If that is the case, simply click the "Build" button on the top right, until the Dockerfile is built (or it uses a cached environment from a previous build). You may be prompted to restart the hardware, which can be done by clicking the link in the error message.
+5. Further, you may encounter a "Build timeout" error. This can be solved by simply building the Dockerfile again.
 
 To test the GAP kernel, simply create a new notebook in Deepnote by clicking on the "Notebooks & Files" tab on the left toolbar, and then the "+" button at the top right of the opened panel. Now, GAP commands can be directly written into the cells in the newly created notebook.
 
 For further information about Jupyter, see https://jupyter-notebook-beginner-guide.readthedocs.io/en/latest/index.html.
 
 # Setting up your own GAP+Deepnote Project
-To get started with your own GAP projects in Deepnote, setup is rather simple:
+To get started with your own GAP projects in a new Deepnote project without duplicating the already set-up stuff, setup is rather simple:
 1. After creating a Deepnote account, create a new project from the dashboard, by clicking the blue "New Project" button.
 2. Clone this repository to get access to the Dockerfile. This can be done by opening a terminal (once the hardware has started up) via the "Terminal" option in the sidebar, clicking the "+" button, and running:
 


### PR DESCRIPTION
Update the launch in deepnote button to go to a published project which will allow users to duplicate a project that is already setup to use the GAP kernel. This will ensure that the environment for such projects defaults to the required Docker image.